### PR TITLE
Add discussions and fix broken spec link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,9 @@ User Controlled Authorization Networks (UCANs) are decentralized, [capabilities 
 
 UCAN is a trustless, secure, local-first, user-originated authorization and revocation scheme. UCAN is designed to be very flexible: you can use it offline, online, fully P2P, federated, or with central servers.
 
-Please see the [specs](#specs) for more detail.
+Please see the [specs](https://github.com/ucan-wg/spec/) for more detail on implementation.
+
+If you're interested in contributing to the development of UCANs, check out the [GitHub Discussions](https://github.com/ucan-wg/spec/discussions).
 
 # Directory
 


### PR DESCRIPTION
I was looking for a direct link to get to the Discussions, since that seems like where a lot of the action is, but you have to just know that the Discussions is nested under the spec repo. I thought it would be helpful to have a link in the org README.

Also noticed that the spec link was broken.

Signed-off-by: Jess Martin <jessmartin@gmail.com>