### PR TITLE
Replace Roadmap section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -53,8 +53,8 @@ Below are listed specifications that are still relevant but should be updated to
   * [Fixture Generator](https://github.com/ucan-wg/ucan-fixture-gen)
 * [Website](https://github.com/ucan-wg/ucan-check)
 
-## Roadmap
-* [Starmap](https://starmap.site/roadmap/github.com/fission-codes/Fission-Starmap/issues/69#view=simple)
+## Project Notes
+* [2025-07-16: spec v1, 3 implementations, upcoming goals, & more](https://github.com/ucan-wg/.github/issues/6)
 
 ## Presentations
 


### PR DESCRIPTION
* Replaces defunct Roadmap section with Project Notes
* Replaces Starmaps link with a (hopefully) more maintainable system for project updates — links to simple issues. They currently live in `.github` but a separate repo could be created if that's better. These issues could hold community call recaps, notes from maintainer's heads, major project updates & plans, etc.

Goal is to make the project feel "alive" for the lowest possible maintenance cost.